### PR TITLE
CRUD'ы отборов (с комментариями) и стеков

### DIFF
--- a/src/main/java/ru/hits/internship/interview/controller/InterviewCommentController.java
+++ b/src/main/java/ru/hits/internship/interview/controller/InterviewCommentController.java
@@ -11,15 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 import ru.hits.internship.common.models.pagination.PagedListDto;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import ru.hits.internship.common.models.response.Response;
 import ru.hits.internship.interview.models.CreateInterviewCommentDto;
 import ru.hits.internship.interview.models.UpdateInterviewCommentDto;
@@ -41,13 +34,13 @@ public class InterviewCommentController {
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping
     public InterviewCommentDto createInterviewComment(
+            @RequestParam("id") @Parameter(description = "Id автора") UUID authorId,
             @PathVariable @Parameter(description = "Id отбора") UUID interviewId,
             @Valid @RequestBody CreateInterviewCommentDto createInterviewCommentDto
     ) {
         //TODO нужно проверить, что у пользователя есть доступ к отбору (т.е. пользователь - либо студент, создавший отбор, либо деканат) (feature/#3932?)
         //TODO нужно получить ID автора (пользователя) из токена (feature/#3932?)
-        //return interviewCommentService.createComment(authorId, interviewId, createInterviewCommentDto);
-        return null;
+        return interviewCommentService.createComment(authorId, interviewId, createInterviewCommentDto);
     }
 
     @Operation(summary = "Обновить комментарий к отбору")

--- a/src/main/java/ru/hits/internship/interview/controller/InterviewCommentController.java
+++ b/src/main/java/ru/hits/internship/interview/controller/InterviewCommentController.java
@@ -5,10 +5,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import ru.hits.internship.common.models.pagination.PagedListDto;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,13 +24,18 @@ import ru.hits.internship.common.models.response.Response;
 import ru.hits.internship.interview.models.CreateInterviewCommentDto;
 import ru.hits.internship.interview.models.UpdateInterviewCommentDto;
 import ru.hits.internship.interview.models.InterviewCommentDto;
+import ru.hits.internship.interview.service.InterviewCommentService;
 
 import java.util.UUID;
 
 @RestController
 @Tag(name = "Комментарии к отборам", description = "Отвечает за работу с комментариями к отборам")
+@RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/interview/{interviewId}/comment")
 public class InterviewCommentController {
+
+    private final InterviewCommentService interviewCommentService;
+
     @Operation(summary = "Создать комментарий к отбору")
     //ID автора берется из токена
     @SecurityRequirement(name = "bearerAuth")
@@ -37,6 +44,9 @@ public class InterviewCommentController {
             @PathVariable @Parameter(description = "Id отбора") UUID interviewId,
             @Valid @RequestBody CreateInterviewCommentDto createInterviewCommentDto
     ) {
+        //TODO нужно проверить, что у пользователя есть доступ к отбору (т.е. пользователь - либо студент, создавший отбор, либо деканат) (feature/#3932?)
+        //TODO нужно получить ID автора (пользователя) из токена (feature/#3932?)
+        //return interviewCommentService.createComment(authorId, interviewId, createInterviewCommentDto);
         return null;
     }
 
@@ -48,7 +58,8 @@ public class InterviewCommentController {
             @PathVariable @Parameter(description = "Id комментария") UUID commentId,
             @Valid @RequestBody UpdateInterviewCommentDto updateInterviewCommentDto
     ) {
-        return null;
+        //TODO нужно проверить, что у пользователя есть доступ к комментарию (т.е. пользователь - автор комментария) (feature/#3932?)
+        return interviewCommentService.updateComment(commentId, updateInterviewCommentDto);
     }
 
     @Operation(summary = "Удалить комментарий к отбору")
@@ -58,7 +69,10 @@ public class InterviewCommentController {
             @PathVariable @Parameter(description = "Id отбора") UUID interviewId,
             @PathVariable @Parameter(description = "Id комментария") UUID commentId
     ) {
-        return null;
+        //TODO нужно проверить, что у пользователя есть доступ к комментарию (т.е. пользователь - автор комментария) (feature/#3932?)
+        interviewCommentService.deleteComment(commentId);
+
+        return new Response("Комментарий успешно удален", HttpStatus.OK.value());
     }
 
     @Operation(summary = "Получить список комментариев к отбору")
@@ -68,6 +82,7 @@ public class InterviewCommentController {
             @PathVariable @Parameter(description = "Id отбора") UUID interviewId,
             @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return null;
+        //TODO нужно проверить, что у пользователя есть доступ к отбору (т.е. пользователь - либо студент, создавший отбор, либо деканат) (feature/#3932?)
+        return interviewCommentService.getCommentList(interviewId, pageable);
     }
 }

--- a/src/main/java/ru/hits/internship/interview/controller/InterviewController.java
+++ b/src/main/java/ru/hits/internship/interview/controller/InterviewController.java
@@ -8,18 +8,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 import ru.hits.internship.common.models.pagination.PagedListDto;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import ru.hits.internship.common.models.response.Response;
 import ru.hits.internship.interview.models.CreateInterviewDto;
 import ru.hits.internship.interview.models.InterviewDto;
@@ -40,10 +32,12 @@ public class InterviewController {
     //ID студента берется из токена
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping
-    public InterviewDto createInterview(@Valid @RequestBody CreateInterviewDto createInterviewDto) {
+    public InterviewDto createInterview(
+            @RequestParam("id") @Parameter(description = "Id студента") UUID studentId,
+            @Valid @RequestBody CreateInterviewDto createInterviewDto
+    ) {
         //TODO нужно получить ID студента из токена (feature/#3932?)
-        //return interviewService.createInterview(studentId, createInterviewDto);
-        return null;
+        return interviewService.createInterview(studentId, createInterviewDto);
     }
 
     @Operation(summary = "Обновить отбор")

--- a/src/main/java/ru/hits/internship/interview/controller/InterviewController.java
+++ b/src/main/java/ru/hits/internship/interview/controller/InterviewController.java
@@ -5,10 +5,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import ru.hits.internship.common.models.pagination.PagedListDto;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,18 +24,25 @@ import ru.hits.internship.common.models.response.Response;
 import ru.hits.internship.interview.models.CreateInterviewDto;
 import ru.hits.internship.interview.models.InterviewDto;
 import ru.hits.internship.interview.models.UpdateInterviewDto;
+import ru.hits.internship.interview.service.InterviewService;
 
 import java.util.UUID;
 
 @RestController
 @Tag(name = "Отборы", description = "Отвечает за работу с отборами")
+@RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/interview")
 public class InterviewController {
+
+    private final InterviewService interviewService;
+
     @Operation(summary = "Создать отбор", description = "Запрос доступен для студентов")
     //ID студента берется из токена
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping
     public InterviewDto createInterview(@Valid @RequestBody CreateInterviewDto createInterviewDto) {
+        //TODO нужно получить ID студента из токена (feature/#3932?)
+        //return interviewService.createInterview(studentId, createInterviewDto);
         return null;
     }
 
@@ -44,7 +53,8 @@ public class InterviewController {
             @PathVariable @Parameter(description = "Id отбора") UUID interviewId,
             @Valid @RequestBody UpdateInterviewDto updateInterviewDto
     ) {
-        return null;
+        //TODO нужно проверить, что у пользователя есть доступ к отбору (т.е. пользователь - либо студент, создавший отбор, либо деканат) (feature/#3932?)
+        return interviewService.updateInterview(interviewId, updateInterviewDto);
     }
 
     @Operation(summary = "Удалить отбор")
@@ -53,7 +63,10 @@ public class InterviewController {
     public Response deleteInterview(
             @PathVariable @Parameter(description = "Id отбора") UUID interviewId
     ) {
-        return null;
+        //TODO нужно проверить, что у пользователя есть доступ к отбору (т.е. пользователь - либо студент, создавший отбор, либо деканат) (feature/#3932?)
+        interviewService.deleteInterview(interviewId);
+
+        return new Response("Отбор успешно удален", HttpStatus.OK.value());
     }
 
     @Operation(summary = "Получить отбор")
@@ -62,7 +75,8 @@ public class InterviewController {
     public InterviewDto getInterview(
             @PathVariable @Parameter(description = "Id отбора") UUID interviewId
     ) {
-        return null;
+        //TODO нужно проверить, что у пользователя есть доступ к отбору (т.е. пользователь - либо студент, создавший отбор, либо деканат) (feature/#3932?)
+        return interviewService.getInterview(interviewId);
     }
 
     @Operation(summary = "Получить список отборов конкретного студента", description = "Запрос доступен для деканата")
@@ -70,17 +84,20 @@ public class InterviewController {
     @GetMapping("/{studentId}/list")
     public PagedListDto<InterviewDto> getInterviewList(
             @PathVariable @Parameter(description = "Id студента") UUID studentId,
-            @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @ParameterObject @PageableDefault Pageable pageable
     ) {
-        return null;
+        //TODO нужно проверить, что пользователь имеет роль деканата (feature/#3932?)
+        return interviewService.getInterviewList(studentId, pageable);
     }
 
     @Operation(summary = "Получить список отборов", description = "Запрос доступен для студентов")
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/list")
     public PagedListDto<InterviewDto> getInterviewList(
-            @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @ParameterObject @PageableDefault Pageable pageable
     ) {
+        //TODO нужно получить ID студента из токена (feature/#3932?)
+        //return interviewService.getInterviewList(studentId, pageable);
         return null;
     }
 

--- a/src/main/java/ru/hits/internship/interview/entity/InterviewCommentEntity.java
+++ b/src/main/java/ru/hits/internship/interview/entity/InterviewCommentEntity.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import ru.hits.internship.user.entity.UserEntity;
 
 import java.time.LocalDateTime;
@@ -31,6 +32,7 @@ public class InterviewCommentEntity {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+    @UpdateTimestamp
     @Column(name = "modified_at", nullable = false)
     private LocalDateTime modifiedAt;
     @Column(name = "content", nullable = false)

--- a/src/main/java/ru/hits/internship/interview/mapper/InterviewCommentMapper.java
+++ b/src/main/java/ru/hits/internship/interview/mapper/InterviewCommentMapper.java
@@ -1,73 +1,21 @@
 package ru.hits.internship.interview.mapper;
 
 import org.mapstruct.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import ru.hits.internship.common.exceptions.NotFoundException;
 import ru.hits.internship.interview.entity.InterviewCommentEntity;
-import ru.hits.internship.interview.entity.InterviewEntity;
 import ru.hits.internship.interview.models.CreateInterviewCommentDto;
 import ru.hits.internship.interview.models.InterviewCommentDto;
 import ru.hits.internship.interview.models.UpdateInterviewCommentDto;
-import ru.hits.internship.interview.repository.InterviewRepository;
-import ru.hits.internship.user.entity.UserEntity;
-import ru.hits.internship.user.models.user.UserDto;
 
-import java.util.UUID;
+//TODO Прикрутить маппер (feature/#3932?)
+@Mapper(componentModel = "spring"/*, uses = {UserMapper.class}*/)
+public interface InterviewCommentMapper {
 
-@Mapper(componentModel = "spring")
-public abstract class InterviewCommentMapper {
-
-    //TODO Прикрутить репозиторий (feature/#3932?)
-//    @Autowired
-//    protected UserRepository userRepository;
-
-    @Autowired
-    protected InterviewRepository interviewRepository;
-
-    //TODO Прикрутить маппер (feature/#3932?)
-//    @Autowired
-//    protected UserMapper userMapper;
-
-    @Mapping(target = "interview", source = "interviewId", qualifiedByName = "mapInterviewId")
-    @Mapping(target = "author", source = "authorId", qualifiedByName = "mapAuthorId")
-    @Mapping(target = "content", source = "dto.content")
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "createdAt", ignore = true)
-    @Mapping(target = "modifiedAt", ignore = true)
-    public abstract InterviewCommentEntity map(UUID authorId, UUID interviewId, CreateInterviewCommentDto dto);
+    @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    InterviewCommentEntity map(CreateInterviewCommentDto dto);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
             unmappedTargetPolicy = ReportingPolicy.IGNORE)
-    @Mapping(target = "content", source = "dto.content")
-    public abstract void update(@MappingTarget InterviewCommentEntity entity, UpdateInterviewCommentDto dto);
+    void update(@MappingTarget InterviewCommentEntity entity, UpdateInterviewCommentDto dto);
 
-    @Mapping(target = "author", source = "author", qualifiedByName = "mapAuthor")
-    public abstract InterviewCommentDto map(InterviewCommentEntity entity);
-
-    @Named("mapAuthor")
-    protected UserDto mapAuthor(UserEntity author) {
-        //TODO Прикрутить маппер (feature/#3932?)
-//        return userMapper.map(author);
-        return null;
-    }
-
-    @Named("mapAuthorId")
-    protected UserEntity mapAuthorId(UUID userId) {
-//        if (!userRepository.existsById(userId)) {
-//            throw new NotFoundException("Пользователь с id %s не найден".formatted(userId));
-//        }
-//
-//        return userRepository.getReferenceById(userId);
-        //TODO Прикрутить репозиторий (feature/#3932?)
-        return null;
-    }
-
-    @Named("mapInterviewId")
-    protected InterviewEntity mapInterviewId(UUID interviewId) {
-        if (!interviewRepository.existsById(interviewId)) {
-            throw new NotFoundException("Отбор с id %s не найден".formatted(interviewId));
-        }
-
-        return interviewRepository.getReferenceById(interviewId);
-    }
+    InterviewCommentDto map(InterviewCommentEntity entity);
 }

--- a/src/main/java/ru/hits/internship/interview/mapper/InterviewCommentMapper.java
+++ b/src/main/java/ru/hits/internship/interview/mapper/InterviewCommentMapper.java
@@ -1,0 +1,73 @@
+package ru.hits.internship.interview.mapper;
+
+import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import ru.hits.internship.common.exceptions.NotFoundException;
+import ru.hits.internship.interview.entity.InterviewCommentEntity;
+import ru.hits.internship.interview.entity.InterviewEntity;
+import ru.hits.internship.interview.models.CreateInterviewCommentDto;
+import ru.hits.internship.interview.models.InterviewCommentDto;
+import ru.hits.internship.interview.models.UpdateInterviewCommentDto;
+import ru.hits.internship.interview.repository.InterviewRepository;
+import ru.hits.internship.user.entity.UserEntity;
+import ru.hits.internship.user.models.user.UserDto;
+
+import java.util.UUID;
+
+@Mapper(componentModel = "spring")
+public abstract class InterviewCommentMapper {
+
+    //TODO Прикрутить репозиторий (feature/#3932?)
+//    @Autowired
+//    protected UserRepository userRepository;
+
+    @Autowired
+    protected InterviewRepository interviewRepository;
+
+    //TODO Прикрутить маппер (feature/#3932?)
+//    @Autowired
+//    protected UserMapper userMapper;
+
+    @Mapping(target = "interview", source = "interviewId", qualifiedByName = "mapInterviewId")
+    @Mapping(target = "author", source = "authorId", qualifiedByName = "mapAuthorId")
+    @Mapping(target = "content", source = "dto.content")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "modifiedAt", ignore = true)
+    public abstract InterviewCommentEntity map(UUID authorId, UUID interviewId, CreateInterviewCommentDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+            unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    @Mapping(target = "content", source = "dto.content")
+    public abstract void update(@MappingTarget InterviewCommentEntity entity, UpdateInterviewCommentDto dto);
+
+    @Mapping(target = "author", source = "author", qualifiedByName = "mapAuthor")
+    public abstract InterviewCommentDto map(InterviewCommentEntity entity);
+
+    @Named("mapAuthor")
+    protected UserDto mapAuthor(UserEntity author) {
+        //TODO Прикрутить маппер (feature/#3932?)
+//        return userMapper.map(author);
+        return null;
+    }
+
+    @Named("mapAuthorId")
+    protected UserEntity mapAuthorId(UUID userId) {
+//        if (!userRepository.existsById(userId)) {
+//            throw new NotFoundException("Пользователь с id %s не найден".formatted(userId));
+//        }
+//
+//        return userRepository.getReferenceById(userId);
+        //TODO Прикрутить репозиторий (feature/#3932?)
+        return null;
+    }
+
+    @Named("mapInterviewId")
+    protected InterviewEntity mapInterviewId(UUID interviewId) {
+        if (!interviewRepository.existsById(interviewId)) {
+            throw new NotFoundException("Отбор с id %s не найден".formatted(interviewId));
+        }
+
+        return interviewRepository.getReferenceById(interviewId);
+    }
+}

--- a/src/main/java/ru/hits/internship/interview/mapper/InterviewMapper.java
+++ b/src/main/java/ru/hits/internship/interview/mapper/InterviewMapper.java
@@ -1,95 +1,23 @@
 package ru.hits.internship.interview.mapper;
 
 import org.mapstruct.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import ru.hits.internship.common.exceptions.NotFoundException;
 import ru.hits.internship.interview.entity.InterviewEntity;
 import ru.hits.internship.interview.models.CreateInterviewDto;
 import ru.hits.internship.interview.models.InterviewDto;
 import ru.hits.internship.interview.models.UpdateInterviewDto;
-import ru.hits.internship.partner.entity.CompanyPartnerEntity;
 import ru.hits.internship.partner.mapper.CompanyPartnerMapper;
-import ru.hits.internship.partner.models.ShortCompanyPartnerDto;
-import ru.hits.internship.partner.repository.CompanyPartnerRepository;
-import ru.hits.internship.stack.entity.StackEntity;
 import ru.hits.internship.stack.mapper.StackMapper;
-import ru.hits.internship.stack.models.StackDto;
-import ru.hits.internship.stack.repository.StackRepository;
-import ru.hits.internship.user.entity.role.StudentEntity;
 
-import java.util.UUID;
+@Mapper(componentModel = "spring", uses = {StackMapper.class, CompanyPartnerMapper.class})
+public interface InterviewMapper {
 
-@Mapper(componentModel = "spring")
-public abstract class InterviewMapper {
-
-    //TODO Прикрутить репозиторий (feature/#3932?)
-//    @Autowired
-//    protected StudentRepository studentRepository;
-
-    @Autowired
-    protected StackRepository stackRepository;
-
-    @Autowired
-    protected CompanyPartnerRepository companyPartnerRepository;
-
-    @Autowired
-    protected StackMapper stackMapper;
-
-    @Autowired
-    protected CompanyPartnerMapper companyPartnerMapper;
-
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "stack", source = "dto.stackId", qualifiedByName = "mapStackId")
-    @Mapping(target = "student", source = "studentId", qualifiedByName = "mapStudentId")
-    @Mapping(target = "company", source = "dto.companyPartnerId", qualifiedByName = "mapCompanyPartnerId")
-    @Mapping(target = "comments", ignore = true)
-    public abstract InterviewEntity map(UUID studentId, CreateInterviewDto dto);
+    @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    InterviewEntity map(CreateInterviewDto dto);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
             unmappedTargetPolicy = ReportingPolicy.IGNORE)
-    @Mapping(target = "stack", source = "stackId", qualifiedByName = "mapStackId")
-    public abstract void update(@MappingTarget InterviewEntity entity, UpdateInterviewDto dto);
+    void update(@MappingTarget InterviewEntity entity, UpdateInterviewDto dto);
 
-    @Mapping(target = "stack", source = "stack", qualifiedByName = "mapStack")
-    @Mapping(target = "companyPartner", source = "company", qualifiedByName = "mapCompany")
-    public abstract InterviewDto map(InterviewEntity entity);
-
-    @Named("mapStack")
-    protected StackDto mapStack(StackEntity stack) {
-        return stackMapper.map(stack);
-    }
-
-    @Named("mapCompany")
-    protected ShortCompanyPartnerDto mapCompany(CompanyPartnerEntity company) {
-        return companyPartnerMapper.toShortDto(company);
-    }
-
-    @Named("mapStudentId")
-    protected StudentEntity mapStudentId(UUID studentId) {
-//        if (!studentRepository.existsById(studentId)) {
-//            throw new NotFoundException("Студент с id %s не найден".formatted(studentId));
-//        }
-//
-//        return studentRepository.getReferenceById(studentId);
-        //TODO Прикрутить репозиторий (feature/#3932?)
-        return null;
-    }
-
-    @Named("mapStackId")
-    protected StackEntity mapStackId(UUID stackId) {
-        if (!stackRepository.existsById(stackId)) {
-            throw new NotFoundException("Стек с id %s не найден".formatted(stackId));
-        }
-
-        return stackRepository.getReferenceById(stackId);
-    }
-
-    @Named("mapCompanyPartnerId")
-    protected CompanyPartnerEntity mapCompanyPartnerId(UUID companyPartnerId) {
-        if (!companyPartnerRepository.existsById(companyPartnerId)) {
-            throw new NotFoundException("Партнер с id %s не найден".formatted(companyPartnerId));
-        }
-
-        return companyPartnerRepository.getReferenceById(companyPartnerId);
-    }
+    @Mapping(target = "companyPartner", source = "company")
+    InterviewDto map(InterviewEntity entity);
 }

--- a/src/main/java/ru/hits/internship/interview/mapper/InterviewMapper.java
+++ b/src/main/java/ru/hits/internship/interview/mapper/InterviewMapper.java
@@ -1,0 +1,95 @@
+package ru.hits.internship.interview.mapper;
+
+import org.mapstruct.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import ru.hits.internship.common.exceptions.NotFoundException;
+import ru.hits.internship.interview.entity.InterviewEntity;
+import ru.hits.internship.interview.models.CreateInterviewDto;
+import ru.hits.internship.interview.models.InterviewDto;
+import ru.hits.internship.interview.models.UpdateInterviewDto;
+import ru.hits.internship.partner.entity.CompanyPartnerEntity;
+import ru.hits.internship.partner.mapper.CompanyPartnerMapper;
+import ru.hits.internship.partner.models.ShortCompanyPartnerDto;
+import ru.hits.internship.partner.repository.CompanyPartnerRepository;
+import ru.hits.internship.stack.entity.StackEntity;
+import ru.hits.internship.stack.mapper.StackMapper;
+import ru.hits.internship.stack.models.StackDto;
+import ru.hits.internship.stack.repository.StackRepository;
+import ru.hits.internship.user.entity.role.StudentEntity;
+
+import java.util.UUID;
+
+@Mapper(componentModel = "spring")
+public abstract class InterviewMapper {
+
+    //TODO Прикрутить репозиторий (feature/#3932?)
+//    @Autowired
+//    protected StudentRepository studentRepository;
+
+    @Autowired
+    protected StackRepository stackRepository;
+
+    @Autowired
+    protected CompanyPartnerRepository companyPartnerRepository;
+
+    @Autowired
+    protected StackMapper stackMapper;
+
+    @Autowired
+    protected CompanyPartnerMapper companyPartnerMapper;
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "stack", source = "dto.stackId", qualifiedByName = "mapStackId")
+    @Mapping(target = "student", source = "studentId", qualifiedByName = "mapStudentId")
+    @Mapping(target = "company", source = "dto.companyPartnerId", qualifiedByName = "mapCompanyPartnerId")
+    @Mapping(target = "comments", ignore = true)
+    public abstract InterviewEntity map(UUID studentId, CreateInterviewDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+            unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    @Mapping(target = "stack", source = "stackId", qualifiedByName = "mapStackId")
+    public abstract void update(@MappingTarget InterviewEntity entity, UpdateInterviewDto dto);
+
+    @Mapping(target = "stack", source = "stack", qualifiedByName = "mapStack")
+    @Mapping(target = "companyPartner", source = "company", qualifiedByName = "mapCompany")
+    public abstract InterviewDto map(InterviewEntity entity);
+
+    @Named("mapStack")
+    protected StackDto mapStack(StackEntity stack) {
+        return stackMapper.map(stack);
+    }
+
+    @Named("mapCompany")
+    protected ShortCompanyPartnerDto mapCompany(CompanyPartnerEntity company) {
+        return companyPartnerMapper.toShortDto(company);
+    }
+
+    @Named("mapStudentId")
+    protected StudentEntity mapStudentId(UUID studentId) {
+//        if (!studentRepository.existsById(studentId)) {
+//            throw new NotFoundException("Студент с id %s не найден".formatted(studentId));
+//        }
+//
+//        return studentRepository.getReferenceById(studentId);
+        //TODO Прикрутить репозиторий (feature/#3932?)
+        return null;
+    }
+
+    @Named("mapStackId")
+    protected StackEntity mapStackId(UUID stackId) {
+        if (!stackRepository.existsById(stackId)) {
+            throw new NotFoundException("Стек с id %s не найден".formatted(stackId));
+        }
+
+        return stackRepository.getReferenceById(stackId);
+    }
+
+    @Named("mapCompanyPartnerId")
+    protected CompanyPartnerEntity mapCompanyPartnerId(UUID companyPartnerId) {
+        if (!companyPartnerRepository.existsById(companyPartnerId)) {
+            throw new NotFoundException("Партнер с id %s не найден".formatted(companyPartnerId));
+        }
+
+        return companyPartnerRepository.getReferenceById(companyPartnerId);
+    }
+}

--- a/src/main/java/ru/hits/internship/interview/repository/InterviewCommentRepository.java
+++ b/src/main/java/ru/hits/internship/interview/repository/InterviewCommentRepository.java
@@ -1,0 +1,15 @@
+package ru.hits.internship.interview.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.hits.internship.interview.entity.InterviewCommentEntity;
+
+import java.util.UUID;
+
+@Repository
+public interface InterviewCommentRepository extends JpaRepository<InterviewCommentEntity, UUID> {
+
+    Page<InterviewCommentEntity> findAllByInterviewId(UUID interviewId, Pageable pageable);
+}

--- a/src/main/java/ru/hits/internship/interview/repository/InterviewRepository.java
+++ b/src/main/java/ru/hits/internship/interview/repository/InterviewRepository.java
@@ -1,0 +1,15 @@
+package ru.hits.internship.interview.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.hits.internship.interview.entity.InterviewEntity;
+
+import java.util.UUID;
+
+@Repository
+public interface InterviewRepository extends JpaRepository<InterviewEntity, UUID> {
+
+    Page<InterviewEntity> findAllByStudentId(UUID studentId, Pageable pageable);
+}

--- a/src/main/java/ru/hits/internship/interview/service/InterviewCommentService.java
+++ b/src/main/java/ru/hits/internship/interview/service/InterviewCommentService.java
@@ -1,0 +1,27 @@
+package ru.hits.internship.interview.service;
+
+import org.springframework.data.domain.Pageable;
+import ru.hits.internship.interview.models.CreateInterviewCommentDto;
+import ru.hits.internship.interview.models.InterviewCommentDto;
+import ru.hits.internship.interview.models.UpdateInterviewCommentDto;
+import ru.hits.internship.common.models.pagination.PagedListDto;
+
+import java.util.UUID;
+
+public interface InterviewCommentService {
+
+    InterviewCommentDto createComment(
+            UUID authorId,
+            UUID interviewId,
+            CreateInterviewCommentDto createInterviewCommentDto
+    );
+
+    InterviewCommentDto updateComment(
+            UUID commentId,
+            UpdateInterviewCommentDto updateInterviewCommentDto
+    );
+
+    void deleteComment(UUID commentId);
+
+    PagedListDto<InterviewCommentDto> getCommentList(UUID interviewId, Pageable pageable);
+}

--- a/src/main/java/ru/hits/internship/interview/service/InterviewService.java
+++ b/src/main/java/ru/hits/internship/interview/service/InterviewService.java
@@ -1,0 +1,22 @@
+package ru.hits.internship.interview.service;
+
+import org.springframework.data.domain.Pageable;
+import ru.hits.internship.interview.models.CreateInterviewDto;
+import ru.hits.internship.interview.models.InterviewDto;
+import ru.hits.internship.interview.models.UpdateInterviewDto;
+import ru.hits.internship.common.models.pagination.PagedListDto;
+
+import java.util.UUID;
+
+public interface InterviewService {
+
+    InterviewDto createInterview(UUID studentId, CreateInterviewDto createInterviewDto);
+
+    InterviewDto updateInterview(UUID interviewId, UpdateInterviewDto updateInterviewDto);
+
+    void deleteInterview(UUID interviewId);
+
+    InterviewDto getInterview(UUID interviewId);
+
+    PagedListDto<InterviewDto> getInterviewList(UUID studentId, Pageable pageable);
+}

--- a/src/main/java/ru/hits/internship/interview/service/impl/InterviewCommentServiceImpl.java
+++ b/src/main/java/ru/hits/internship/interview/service/impl/InterviewCommentServiceImpl.java
@@ -1,0 +1,58 @@
+package ru.hits.internship.interview.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.hits.internship.common.exceptions.NotFoundException;
+import ru.hits.internship.common.models.pagination.PagedListDto;
+import ru.hits.internship.interview.entity.InterviewCommentEntity;
+import ru.hits.internship.interview.mapper.InterviewCommentMapper;
+import ru.hits.internship.interview.models.CreateInterviewCommentDto;
+import ru.hits.internship.interview.models.InterviewCommentDto;
+import ru.hits.internship.interview.models.UpdateInterviewCommentDto;
+import ru.hits.internship.interview.repository.InterviewCommentRepository;
+import ru.hits.internship.interview.service.InterviewCommentService;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewCommentServiceImpl implements InterviewCommentService {
+
+    private final InterviewCommentRepository repository;
+    private final InterviewCommentMapper mapper;
+
+    @Override
+    @Transactional
+    public InterviewCommentDto createComment(UUID authorId, UUID interviewId, CreateInterviewCommentDto createInterviewCommentDto) {
+        return mapper.map(repository.save(mapper.map(authorId, interviewId, createInterviewCommentDto)));
+    }
+
+    @Override
+    @Transactional
+    public InterviewCommentDto updateComment(UUID commentId, UpdateInterviewCommentDto updateInterviewCommentDto) {
+        InterviewCommentEntity comment = repository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException("Комментарий с id %s не найден".formatted(commentId)));
+
+        mapper.update(comment, updateInterviewCommentDto);
+        InterviewCommentEntity savedComment = repository.save(comment);
+
+        return mapper.map(savedComment);
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(UUID commentId) {
+        InterviewCommentEntity comment = repository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException("Комментарий с id %s не найден".formatted(commentId)));
+
+        repository.delete(comment);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PagedListDto<InterviewCommentDto> getCommentList(UUID interviewId, Pageable pageable) {
+        return new PagedListDto<>(repository.findAllByInterviewId(interviewId, pageable).map(mapper::map));
+    }
+}

--- a/src/main/java/ru/hits/internship/interview/service/impl/InterviewCommentServiceImpl.java
+++ b/src/main/java/ru/hits/internship/interview/service/impl/InterviewCommentServiceImpl.java
@@ -1,18 +1,22 @@
 package ru.hits.internship.interview.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.hits.internship.common.exceptions.NotFoundException;
 import ru.hits.internship.common.models.pagination.PagedListDto;
 import ru.hits.internship.interview.entity.InterviewCommentEntity;
+import ru.hits.internship.interview.entity.InterviewEntity;
 import ru.hits.internship.interview.mapper.InterviewCommentMapper;
 import ru.hits.internship.interview.models.CreateInterviewCommentDto;
 import ru.hits.internship.interview.models.InterviewCommentDto;
 import ru.hits.internship.interview.models.UpdateInterviewCommentDto;
 import ru.hits.internship.interview.repository.InterviewCommentRepository;
+import ru.hits.internship.interview.repository.InterviewRepository;
 import ru.hits.internship.interview.service.InterviewCommentService;
+import ru.hits.internship.user.entity.UserEntity;
 
 import java.util.UUID;
 
@@ -20,39 +24,59 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class InterviewCommentServiceImpl implements InterviewCommentService {
 
-    private final InterviewCommentRepository repository;
-    private final InterviewCommentMapper mapper;
+    private final InterviewCommentRepository commentRepository;
+    private final InterviewCommentMapper commentMapper;
+    //TODO Прикрутить репозиторий (feature/#3932?)
+    //private final UserRepository userRepository;
+    private final InterviewRepository interviewRepository;
 
     @Override
     @Transactional
     public InterviewCommentDto createComment(UUID authorId, UUID interviewId, CreateInterviewCommentDto createInterviewCommentDto) {
-        return mapper.map(repository.save(mapper.map(authorId, interviewId, createInterviewCommentDto)));
+        InterviewCommentEntity entity = commentMapper.map(createInterviewCommentDto);
+
+        //if (!userRepository.existsById(authorId)) {
+        //    throw new NotFoundException("Пользователь с id %s не найден".formatted(authorId));
+        //}
+        //UserEntity author = userRepository.getReferenceById(authorId);
+        //entity.setAuthor(author);
+
+        if (!interviewRepository.existsById(interviewId)) {
+            throw new NotFoundException("Отбор с id %s не найден".formatted(interviewId));
+        }
+        InterviewEntity interview = interviewRepository.getReferenceById(interviewId);
+        entity.setInterview(interview);
+
+        InterviewCommentEntity savedEntity = commentRepository.save(entity);
+        return commentMapper.map(savedEntity);
     }
 
     @Override
     @Transactional
     public InterviewCommentDto updateComment(UUID commentId, UpdateInterviewCommentDto updateInterviewCommentDto) {
-        InterviewCommentEntity comment = repository.findById(commentId)
+        InterviewCommentEntity comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new NotFoundException("Комментарий с id %s не найден".formatted(commentId)));
 
-        mapper.update(comment, updateInterviewCommentDto);
-        InterviewCommentEntity savedComment = repository.save(comment);
+        commentMapper.update(comment, updateInterviewCommentDto);
+        InterviewCommentEntity savedComment = commentRepository.save(comment);
 
-        return mapper.map(savedComment);
+        return commentMapper.map(savedComment);
     }
 
     @Override
     @Transactional
     public void deleteComment(UUID commentId) {
-        InterviewCommentEntity comment = repository.findById(commentId)
+        InterviewCommentEntity comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new NotFoundException("Комментарий с id %s не найден".formatted(commentId)));
 
-        repository.delete(comment);
+        commentRepository.delete(comment);
     }
 
     @Override
     @Transactional(readOnly = true)
     public PagedListDto<InterviewCommentDto> getCommentList(UUID interviewId, Pageable pageable) {
-        return new PagedListDto<>(repository.findAllByInterviewId(interviewId, pageable).map(mapper::map));
+        Page<InterviewCommentEntity> page = commentRepository.findAllByInterviewId(interviewId, pageable);
+
+        return new PagedListDto<>(page.map(commentMapper::map));
     }
 }

--- a/src/main/java/ru/hits/internship/interview/service/impl/InterviewServiceImpl.java
+++ b/src/main/java/ru/hits/internship/interview/service/impl/InterviewServiceImpl.java
@@ -1,0 +1,66 @@
+package ru.hits.internship.interview.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.hits.internship.common.exceptions.NotFoundException;
+import ru.hits.internship.common.models.pagination.PagedListDto;
+import ru.hits.internship.interview.entity.InterviewEntity;
+import ru.hits.internship.interview.mapper.InterviewMapper;
+import ru.hits.internship.interview.models.CreateInterviewDto;
+import ru.hits.internship.interview.models.InterviewDto;
+import ru.hits.internship.interview.models.UpdateInterviewDto;
+import ru.hits.internship.interview.repository.InterviewRepository;
+import ru.hits.internship.interview.service.InterviewService;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewServiceImpl implements InterviewService {
+
+    private final InterviewRepository repository;
+    private final InterviewMapper mapper;
+
+    @Override
+    @Transactional
+    public InterviewDto createInterview(UUID studentId, CreateInterviewDto createInterviewDto) {
+        return mapper.map(repository.save(mapper.map(studentId, createInterviewDto)));
+    }
+
+    @Override
+    @Transactional
+    public InterviewDto updateInterview(UUID interviewId, UpdateInterviewDto updateInterviewDto) {
+        InterviewEntity interview = repository.findById(interviewId)
+                .orElseThrow(() -> new NotFoundException("Интервью с id %s не найдено".formatted(interviewId)));
+
+        mapper.update(interview, updateInterviewDto);
+        InterviewEntity savedInterview = repository.save(interview);
+
+        return mapper.map(savedInterview);
+    }
+
+    @Override
+    @Transactional
+    public void deleteInterview(UUID interviewId) {
+        InterviewEntity interview = repository.findById(interviewId)
+                .orElseThrow(() -> new NotFoundException("Интервью с id %s не найдено".formatted(interviewId)));
+
+        repository.delete(interview);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public InterviewDto getInterview(UUID interviewId) {
+        return repository.findById(interviewId)
+                .map(mapper::map)
+                .orElseThrow(() -> new NotFoundException("Интервью с id %s не найдено".formatted(interviewId)));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PagedListDto<InterviewDto> getInterviewList(UUID studentId, Pageable pageable) {
+        return new PagedListDto<>(repository.findAllByStudentId(studentId, pageable).map(mapper::map));
+    }
+}

--- a/src/main/java/ru/hits/internship/stack/controller/StackController.java
+++ b/src/main/java/ru/hits/internship/stack/controller/StackController.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,14 +19,20 @@ import org.springframework.web.bind.annotation.RestController;
 import ru.hits.internship.common.models.response.Response;
 import ru.hits.internship.stack.models.CreateStackDto;
 import ru.hits.internship.stack.models.StackDto;
+import ru.hits.internship.stack.models.UpdateStackDto;
+import ru.hits.internship.stack.service.StackService;
 
 import java.util.List;
 import java.util.UUID;
 
 @RestController
 @Tag(name = "Стек", description = "Отвечает за работу со стеками")
+@RequiredArgsConstructor
 @RequestMapping(value = "/api/v1/stack")
 public class StackController {
+
+    private final StackService stackService;
+
     @Operation(
             summary = "Получить список стеков",
             description = "Позволяет получить список доступных стеков"
@@ -34,16 +42,17 @@ public class StackController {
     public List<StackDto> getStackList(
             @RequestParam(name = "query") @Parameter(description = "Название стека") String query
     ) {
-        return null;
+        return stackService.getAllStacks(query);
     }
 
     @Operation(summary = "Создать стек")
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping
     public StackDto createStack(
-            @Valid @RequestBody CreateStackDto createUpdateStackDto
+            @Valid @RequestBody CreateStackDto createStackDto
     ) {
-        return null;
+        //TODO добавить проверку на наличие роли куратора/деканата у вызывающего (feature/#3932?)
+        return stackService.createStack(createStackDto);
     }
 
     @Operation(summary = "Обновить стек")
@@ -51,9 +60,10 @@ public class StackController {
     @PutMapping("/{stackId}")
     public StackDto updateStack(
             @PathVariable @Parameter(description = "Идентификатор стека", required = true) UUID stackId,
-            @Valid @RequestBody CreateStackDto createUpdateStackDto
+            @Valid @RequestBody UpdateStackDto updateStackDto
     ) {
-        return null;
+        //TODO добавить проверку на наличие роли куратора/деканата у вызывающего (feature/#3932?)
+        return stackService.updateStack(stackId, updateStackDto);
     }
 
     @Operation(summary = "Удалить стек")
@@ -62,6 +72,9 @@ public class StackController {
     public Response deleteStack(
             @PathVariable @Parameter(description = "Идентификатор стека", required = true) UUID stackId
     ) {
-        return null;
+        //TODO добавить проверку на наличие роли куратора/деканата у вызывающего (feature/#3932?)
+        stackService.deleteStack(stackId);
+
+        return new Response("Стек успешно удален", HttpStatus.OK.value());
     }
 }

--- a/src/main/java/ru/hits/internship/stack/mapper/StackMapper.java
+++ b/src/main/java/ru/hits/internship/stack/mapper/StackMapper.java
@@ -1,0 +1,20 @@
+package ru.hits.internship.stack.mapper;
+
+import org.mapstruct.*;
+import ru.hits.internship.stack.entity.StackEntity;
+import ru.hits.internship.stack.models.CreateStackDto;
+import ru.hits.internship.stack.models.StackDto;
+import ru.hits.internship.stack.models.UpdateStackDto;
+
+@Mapper(componentModel = "spring")
+public interface StackMapper {
+
+    @Mapping(target = "id", ignore = true)
+    StackEntity map(CreateStackDto createStackDto);
+
+    StackDto map(StackEntity stackEntity);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+            unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    void update(@MappingTarget StackEntity stackEntity, UpdateStackDto updateStackDto);
+}

--- a/src/main/java/ru/hits/internship/stack/repository/StackRepository.java
+++ b/src/main/java/ru/hits/internship/stack/repository/StackRepository.java
@@ -1,18 +1,16 @@
 package ru.hits.internship.stack.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import ru.hits.internship.stack.entity.StackEntity;
 
-import java.util.List;
 import java.util.UUID;
 
 @Repository
-public interface StackRepository extends JpaRepository<StackEntity, UUID> {
+public interface StackRepository extends JpaRepository<StackEntity, UUID>, JpaSpecificationExecutor<StackEntity> {
 
     boolean existsByName(String name);
 
     boolean existsByNameAndIdNot(String name, UUID id);
-
-    List<StackEntity> findAllByName(String name);
 }

--- a/src/main/java/ru/hits/internship/stack/repository/StackRepository.java
+++ b/src/main/java/ru/hits/internship/stack/repository/StackRepository.java
@@ -1,0 +1,18 @@
+package ru.hits.internship.stack.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ru.hits.internship.stack.entity.StackEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface StackRepository extends JpaRepository<StackEntity, UUID> {
+
+    boolean existsByName(String name);
+
+    boolean existsByNameAndIdNot(String name, UUID id);
+
+    List<StackEntity> findAllByName(String name);
+}

--- a/src/main/java/ru/hits/internship/stack/service/StackService.java
+++ b/src/main/java/ru/hits/internship/stack/service/StackService.java
@@ -1,0 +1,19 @@
+package ru.hits.internship.stack.service;
+
+import ru.hits.internship.stack.models.CreateStackDto;
+import ru.hits.internship.stack.models.StackDto;
+import ru.hits.internship.stack.models.UpdateStackDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface StackService {
+
+    List<StackDto> getAllStacks(String query);
+
+    StackDto createStack(CreateStackDto createStackDto);
+
+    StackDto updateStack(UUID stackId, UpdateStackDto updateStackDto);
+
+    void deleteStack(UUID stackId);
+}

--- a/src/main/java/ru/hits/internship/stack/service/impl/StackServiceImpl.java
+++ b/src/main/java/ru/hits/internship/stack/service/impl/StackServiceImpl.java
@@ -1,0 +1,73 @@
+package ru.hits.internship.stack.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.hits.internship.common.exceptions.AlreadyExistsException;
+import ru.hits.internship.common.exceptions.NotFoundException;
+import ru.hits.internship.stack.entity.StackEntity;
+import ru.hits.internship.stack.mapper.StackMapper;
+import ru.hits.internship.stack.models.CreateStackDto;
+import ru.hits.internship.stack.models.StackDto;
+import ru.hits.internship.stack.models.UpdateStackDto;
+import ru.hits.internship.stack.repository.StackRepository;
+import ru.hits.internship.stack.service.StackService;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StackServiceImpl implements StackService {
+
+    private final StackRepository repository;
+    private final StackMapper mapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<StackDto> getAllStacks(String query) {
+        if (query == null || query.isBlank()) {
+            return repository.findAll().stream().map(mapper::map).toList();
+        } else {
+            return repository.findAllByName(query).stream().map(mapper::map).toList();
+        }
+    }
+
+    @Override
+    @Transactional
+    public StackDto createStack(CreateStackDto createStackDto) {
+        if (repository.existsByName(createStackDto.getName())) {
+            throw new AlreadyExistsException("Стек с именем \"%s\" уже существует".formatted(createStackDto.getName()));
+        }
+
+        StackEntity stack = mapper.map(createStackDto);
+        StackEntity savedStack = repository.save(stack);
+
+        return mapper.map(savedStack);
+    }
+
+    @Override
+    @Transactional
+    public StackDto updateStack(UUID stackId, UpdateStackDto updateStackDto) {
+        if (repository.existsByNameAndIdNot(updateStackDto.getName(), stackId)) {
+            throw new AlreadyExistsException("Стек с именем \"%s\" уже существует".formatted(updateStackDto.getName()));
+        }
+
+        StackEntity stack = repository.findById(stackId)
+                .orElseThrow(() -> new NotFoundException("Стек с id %s не найден".formatted(stackId)));
+
+        mapper.update(stack, updateStackDto);
+        StackEntity savedStack = repository.save(stack);
+
+        return mapper.map(savedStack);
+    }
+
+    @Override
+    @Transactional
+    public void deleteStack(UUID stackId) {
+        StackEntity stack = repository.findById(stackId)
+                .orElseThrow(() -> new NotFoundException("Стек с id %s не найден".formatted(stackId)));
+
+        repository.delete(stack);
+    }
+}

--- a/src/main/java/ru/hits/internship/stack/service/impl/StackServiceImpl.java
+++ b/src/main/java/ru/hits/internship/stack/service/impl/StackServiceImpl.java
@@ -1,6 +1,7 @@
 package ru.hits.internship.stack.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.hits.internship.common.exceptions.AlreadyExistsException;
@@ -12,6 +13,7 @@ import ru.hits.internship.stack.models.StackDto;
 import ru.hits.internship.stack.models.UpdateStackDto;
 import ru.hits.internship.stack.repository.StackRepository;
 import ru.hits.internship.stack.service.StackService;
+import ru.hits.internship.stack.specification.StackSpecification;
 
 import java.util.List;
 import java.util.UUID;
@@ -26,11 +28,10 @@ public class StackServiceImpl implements StackService {
     @Override
     @Transactional(readOnly = true)
     public List<StackDto> getAllStacks(String query) {
-        if (query == null || query.isBlank()) {
-            return repository.findAll().stream().map(mapper::map).toList();
-        } else {
-            return repository.findAllByName(query).stream().map(mapper::map).toList();
-        }
+        Specification<StackEntity> spec = StackSpecification.hasName(query);
+        List<StackEntity> stacks = repository.findAll(spec);
+
+        return stacks.stream().map(mapper::map).toList();
     }
 
     @Override

--- a/src/main/java/ru/hits/internship/stack/specification/StackSpecification.java
+++ b/src/main/java/ru/hits/internship/stack/specification/StackSpecification.java
@@ -1,0 +1,15 @@
+package ru.hits.internship.stack.specification;
+
+import org.springframework.data.jpa.domain.Specification;
+import ru.hits.internship.stack.entity.StackEntity;
+
+public class StackSpecification {
+    public static Specification<StackEntity> hasName(String name) {
+        return (root, query, criteriaBuilder) -> {
+            if (name == null || name.isBlank()) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.like(root.get("name"), "%" + name + "%");
+        };
+    }
+}


### PR DESCRIPTION
Вся логика CRUD'а есть, однако эндпоинты отборов и комментариев сейчас не получится использовать, т.к. нет авторизации (например, для создания отбора нужен ID студента, а без авторизации получить его невозможно).

Ещё в текущей реализации нет проверок, связанных с авторизацией (например, при редактировании отбора нет проверки на то, что вызывающий пользователь - деканат или студент, создавший отбор); эти проверки я добавлю, когда появится авторизация (я бы мог частично реализовать эти проверки и сейчас, но решил этого не делать, чтобы в случае чего не переписывать эту логику).

Для всех недоделанных моментов оставил TODO'шки.

UPD: Сейчас заметил, что неправильный номер задачи поставил в ветке, должно быть feature/#3934